### PR TITLE
Implements movement cost mechanism (closes #14)

### DIFF
--- a/src/Forkwars/World/Terrain/Terrain.php
+++ b/src/Forkwars/World/Terrain/Terrain.php
@@ -16,6 +16,9 @@ class Terrain extends Thing
 {
     public function __construct(array $metadata = array())
     {
+        if(!isset($metadata["movementCost"])) {
+          $metadata["movementCost"] = 100;
+        }
         $this->metadata = $metadata;
     }
 

--- a/src/Forkwars/World/Terrain/Terrain.php
+++ b/src/Forkwars/World/Terrain/Terrain.php
@@ -32,14 +32,6 @@ class Terrain extends Thing
         return $this->returnMandatoryMetadata('movementCost');
     }
 
-    private function returnMandatoryMetadata($name)
-    {
-        if(! isset($this->metadata[$name])){
-            throw new \LogicException($name . ' shall be set');
-        }
-        return $this->metadata[$name];
-    }
-
     /**
      * {@inheritdoc}
      *

--- a/src/Forkwars/World/Thing.php
+++ b/src/Forkwars/World/Thing.php
@@ -163,4 +163,12 @@ class Thing
     {
         throw new \Exception('Cannot register reference');
     }
+
+    protected function returnMandatoryMetadata($name)
+    {
+        if(! isset($this->metadata[$name])){
+            throw new \LogicException($name . ' shall be set');
+        }
+        return $this->metadata[$name];
+    }
 }

--- a/src/Forkwars/World/Unit/Unit.php
+++ b/src/Forkwars/World/Unit/Unit.php
@@ -24,13 +24,6 @@ class Unit extends Thing
         $this->metadata = $metadata;
         $this->metadata['currentMovementLeft'] = $this->metadata['maxMovementByTurn'];
     }
-    private function returnMandatoryMetadata($name)
-    {
-        if(! isset($this->metadata[$name])){
-            throw new \LogicException($name . ' shall be set');
-        }
-        return $this->metadata[$name];
-    }
     public function getName()
     {
         return 'infantry';
@@ -52,7 +45,6 @@ class Unit extends Thing
     {
         return $this->getParent()->getPosition();
     }
-
     public function log($message)
     {
         $this->registerAction(new Action($this, 'log', $message));

--- a/src/Forkwars/World/World.php
+++ b/src/Forkwars/World/World.php
@@ -182,7 +182,9 @@ class World extends Thing
         // Resets all Unit movement credits
         $unit_list = $this->find("infantry");
         foreach($unit_list as $unit) {
-          $unit->resetMovementLeft();
+          if($unit instanceof Unit) {
+            $unit->resetMovementLeft();
+          }
         }
     }
 

--- a/src/Forkwars/World/World.php
+++ b/src/Forkwars/World/World.php
@@ -179,6 +179,11 @@ class World extends Thing
             throw new GameException('Please first finish the current turn');
         }
         $this->currentTurn = new Turn();
+        // Resets all Unit movement credits
+        $unit_list = $this->find("infantry");
+        foreach($unit_list as $unit) {
+          $unit->resetMovementLeft();
+        }
     }
 
     public function endTurn()

--- a/tests/Unit/UnitTest.php
+++ b/tests/Unit/UnitTest.php
@@ -40,7 +40,7 @@ class UnitTest extends \PHPUnit_Framework_TestCase
         $to   = new Terrain(array('movementCost' => 200));  $to->setPosition(new Position(0, 3));
 
         // Test
-        $dut = new \Forkwars\World\Unit\Unit();
+        $dut = new \Forkwars\World\Unit\Unit(array("maxMovementByTurn" => 200));
         $dut->setParent($from);
         $dut->moveTo($a);
         $dut->moveTo($b);

--- a/tests/World/WorldTest.php
+++ b/tests/World/WorldTest.php
@@ -12,8 +12,8 @@ class WorldTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
 
         $this->dut = new \Forkwars\World\World('test', 2, 1);
-        $this->ter1 = new \Forkwars\World\Terrain\Terrain(array());
-        $this->ter2 = new \Forkwars\World\Terrain\Terrain(array());
+        $this->ter1 = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100,"name" => "ter1"));
+        $this->ter2 = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100, "name" => "ter2"));
 
         $this->ter1->setPosition(new \Forkwars\Position(0,0))->attachTo($this->dut);
         $this->ter2->setPosition(new \Forkwars\Position(1,0))->attachTo($this->dut);
@@ -38,5 +38,21 @@ class WorldTest extends \PHPUnit_Framework_TestCase
         $turn = $this->dut->endTurn();
         $this->assertInstanceOf('Forkwars\Game\Turn', $turn);
         $this->assertCount(1, $turn);
+    }
+
+    public function testResetMovementLeftOnTurn()
+    {
+      $this->dut->startTurn();
+
+      $unit = new \Forkwars\World\Unit\Unit();
+      $this->ter1->addChild($unit);
+      $unit->moveTo($this->ter2);
+      $unit->moveTo($this->ter1);
+      $this->assertEquals($unit->getMovementLeft(),0);
+
+      $turn = $this->dut->endTurn();
+      $this->dut->startTurn();
+      $this->assertEquals($unit->getMovementLeft(),200);
+
     }
 }


### PR DESCRIPTION
Hi @dav-m85 

This implements the movement cost mechanism. I have done it in a similar way as in `Terrain` metadata, by including two properties, `currentMovementLeft` and `maxMovementByTurn` on `Unit`. These properties are checked and updated on `canMove` method in `Unit`.

In order to not to break existing tests, there're a couple of `instanceof Terrain` since `$destination` is of type `Thing`. 

You also mentioned that the exception should be raised when credit movement reaches zero. I have, however, thrown the excepetion when credit is no longer enough to move (say credit is 50 but cost is 100). Is that ok? If not so, let me know.

At last, code for resetting the credits is very simple, searching for all `infantry` and calling their reset methods. I have wrote a test for that in `WorldTest.php`

I'll wait for Travis tests to complete and fix them in case something goes wrong.