### PR TITLE
Adds test and fixes bug on getNeighboringPositions (closes #17)

### DIFF
--- a/src/Forkwars/World/World.php
+++ b/src/Forkwars/World/World.php
@@ -137,8 +137,8 @@ class World extends Thing
         $world = $this;
 
         return array_filter(array($n, $s, $w, $e), function (Position $p) use ($world) {
-            return ! ( $p->y < 0 || $world->height < $p->y ||
-                $p->x < 0 || $world->width < $p->x );
+            return ! ( $p->y < 0 || $world->height <= $p->y ||
+                $p->x < 0 || $world->width <= $p->x );
         });
     }
 

--- a/tests/World/WorldTest.php
+++ b/tests/World/WorldTest.php
@@ -11,12 +11,24 @@ class WorldTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->dut = new \Forkwars\World\World('test', 2, 1);
+        $this->dut = new \Forkwars\World\World('test', 4, 4);
         $this->ter1 = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100,"name" => "ter1"));
         $this->ter2 = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100, "name" => "ter2"));
 
+        $this->ter_bottom_left = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100,"name" => "ter_bottom_left"));
+        $this->ter_bottom_right = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100, "name" => "ter_bottom_right"));
+        $this->ter_upper_left = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100,"name" => "ter_upper_left"));
+        $this->ter_upper_right = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100, "name" => "ter_upper_right"));
+        $this->ter_middle = new \Forkwars\World\Terrain\Terrain(array("movementCost" => 100, "name" => "ter_middle"));
+
         $this->ter1->setPosition(new \Forkwars\Position(0,0))->attachTo($this->dut);
         $this->ter2->setPosition(new \Forkwars\Position(1,0))->attachTo($this->dut);
+
+        $this->ter_bottom_left->setPosition(new \Forkwars\Position(0,0))->attachTo($this->dut);
+        $this->ter_bottom_right->setPosition(new \Forkwars\Position(3,0))->attachTo($this->dut);
+        $this->ter_upper_left->setPosition(new \Forkwars\Position(0,3))->attachTo($this->dut);
+        $this->ter_upper_right->setPosition(new \Forkwars\Position(3,3))->attachTo($this->dut);
+        $this->ter_middle->setPosition(new \Forkwars\Position(1,1))->attachTo($this->dut);
     }
 
     public function testRegisterActionNoTurn()
@@ -55,4 +67,66 @@ class WorldTest extends \PHPUnit_Framework_TestCase
       $this->assertEquals($unit->getMovementLeft(),200);
 
     }
+
+    public function testNeighborPositions()
+    {
+      // Test bottom left
+      $neighbors = $this->dut->getNeighboringPositions($this->ter_bottom_left->getPosition());
+      $count_neighbors = count($neighbors);
+      $this->assertEquals($count_neighbors,2);
+      foreach($neighbors as $neighbor) {
+        if(($neighbor->x == 0 && $neighbor->y == 1) || ($neighbor->x == 1 && $neighbor->y == 0)) {
+          $count_neighbors--;
+        }
+      }
+      $this->assertEquals($count_neighbors,0);
+
+      // Test bottom right
+      $neighbors = $this->dut->getNeighboringPositions($this->ter_bottom_right->getPosition());
+      $count_neighbors = count($neighbors);
+      $this->assertEquals($count_neighbors,2);
+      foreach($neighbors as $neighbor) {
+        if(($neighbor->x == 3 && $neighbor->y == 1) || ($neighbor->x == 2 && $neighbor->y == 0)) {
+          $count_neighbors--;
+        }
+      }
+      $this->assertEquals($count_neighbors,0);
+
+      // Test upper left
+      $neighbors = $this->dut->getNeighboringPositions($this->ter_upper_left->getPosition());
+      $count_neighbors = count($neighbors);
+      $this->assertEquals($count_neighbors,2);
+      foreach($neighbors as $neighbor) {
+        if(($neighbor->x == 1 && $neighbor->y == 3) || ($neighbor->x == 0 && $neighbor->y == 2)) {
+          $count_neighbors--;
+        }
+      }
+      $this->assertEquals($count_neighbors,0);
+
+      // Test upper right
+      $neighbors = $this->dut->getNeighboringPositions($this->ter_upper_right->getPosition());
+      $count_neighbors = count($neighbors);
+      $this->assertEquals($count_neighbors,2);
+      foreach($neighbors as $neighbor) {
+        if(($neighbor->x == 2 && $neighbor->y == 3) || ($neighbor->x == 3 && $neighbor->y == 2)) {
+          $count_neighbors--;
+        }
+      }
+      $this->assertEquals($count_neighbors,0);
+
+      // Test Middle
+      $neighbors = $this->dut->getNeighboringPositions($this->ter_middle->getPosition());
+      $count_neighbors = count($neighbors);
+      $this->assertEquals($count_neighbors,4);
+      foreach($neighbors as $neighbor) {
+        if(($neighbor->x == 0 && $neighbor->y == 1) || ($neighbor->x == 2 && $neighbor->y == 1)
+         || ($neighbor->x == 1 && $neighbor->y == 0) || ($neighbor->x == 1 && $neighbor->y == 2)) {
+          $count_neighbors--;
+        }
+      }
+      $this->assertEquals($count_neighbors,0);
+
+    }
+
+
 }


### PR DESCRIPTION
Hey again @dav-m85 

I have noticed this issue pending so I gave it a shot. I have also noticed a small bug on borders.

Former condition evaluated:

```
return ! ( $p->y < 0 || $world->height < $p->y ||
            $p->x < 0 || $world->width < $p->x );
```

However I have set up a 4x4 world, and when asking for neighbors to (3,0), (4,0) was being returned as a valid spot. I have changed it to fix that.

Code checks the four corners and a middle of the board position. It could also check for wall positions such as (0,1) but I think it's just a little bit of copy-paste so I left that aside.

Thank you!
